### PR TITLE
use jaccard() in glacier example

### DIFF
--- a/viamr/viamr.py
+++ b/viamr/viamr.py
@@ -167,8 +167,14 @@ class VIAMR(OptionsManager):
         two sets is
             J(S,T) = |S \cap T| / |S \cup T|,
         that is, the ratio of the area (measure) of the intersection
-        divided by the ares of the union.'''
+        divided by the area of the union.
+        Warning: Not valid in parallel.'''
         # FIXME how to check that active1, active2 are in DG0 spaces?
+        # FIXME fails in parallel; the line generating proj2 will throw
+        #     AssertionError: Whoever made mesh_B should explicitly mark
+        #     mesh_A as having a compatible parallel layout.
+        assert active1.function_space().mesh()._comm.size == 1, \
+               'jaccard() not valid in parallel'
         if self.debug:
             for a in [active1, active2]:
                 assert min(a.dat.data_ro) >= 0.0

--- a/viamr/viamr.py
+++ b/viamr/viamr.py
@@ -165,7 +165,7 @@ class VIAMR(OptionsManager):
         set indicators.  These indicators must be DG0 functions, but they
         can be on different meshes.  By definition, the Jaccard metric of
         two sets is
-            J(S,T) = |S \cap T| / |S \cup T|,
+            J(S,T) = |S cap T| / |S cup T|,
         that is, the ratio of the area (measure) of the intersection
         divided by the area of the union.
         Warning: Not valid in parallel.'''


### PR DESCRIPTION
I will try to make my changes in branches from now on.  (Assuming that makes merging easier.)

Note that jaccard() definitely fails in parallel.  But I think we can add a "has compatible parallel" when we call refine marked elements?