### PR TITLE
added a test which uses no netgen at all

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -93,8 +93,8 @@ def test_refine_vces():
     ru = Function(rV).interpolate(u) # cross-mesh interpolation
     assert abs(norm(ru) - unorm0) < 1.0e-10 # ... should be conservative
     VTKFile(f"netgen_result_refine_1.pvd").write(ru)
-    
-    
+
+
 def test_petsc4py_refine_vces():
     mesh = get_netgen_mesh(TriHeight=1.2)
     z = VIAMR(debug=True)
@@ -104,8 +104,6 @@ def test_petsc4py_refine_vces():
     psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
     u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
     unorm0 = norm(u)
-    # from firedrake.output import VTKFile
-    # VTKFile(f"result_refine_0.pvd").write(u)
     mark = z.vcesmark(mesh, u, psi)
     rmesh = z.refinemarkedelements(mesh, mark)
     rCG1, _ = z.spaces(rmesh)
@@ -114,6 +112,28 @@ def test_petsc4py_refine_vces():
     ru = Function(rV).interpolate(u)  # cross-mesh interpolation
     assert abs(norm(ru) - unorm0) < 1.0e-10  # ... should be conservative
     VTKFile(f"petsc4py_result_refine_1.pvd").write(ru)
+
+
+def test_refine_vces_petsc4py_firedrake():
+    mesh = RectangleMesh(5, 5, 4.0, 4.0)  # Firedrake utility mesh, not netgen
+    mesh.coordinates.dat.data[:] -= 2.0
+    z = VIAMR(debug=True)
+    CG1, _ = z.spaces(mesh)
+    assert CG1.dim() == 36
+    (x, y) = SpatialCoordinate(mesh)
+    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
+    u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
+    unorm0 = norm(u)
+    VTKFile(f"result_0.pvd").write(u)
+    mark = z.vcesmark(mesh, u, psi)
+    rmesh = z.refinemarkedelements(mesh, mark)
+    rmesh.coordinates.dat.data[:] -= 2.0  # FIXME why needed?
+    rCG1, _ = z.spaces(rmesh)
+    assert rCG1.dim() == 73
+    rV = FunctionSpace(rmesh, "CG", 1)
+    ru = Function(rV).interpolate(u)  # cross-mesh interpolation
+    assert abs(norm(ru) - unorm0) < 1.0e-10  # ... should be conservative
+    VTKFile(f"result_1.pvd").write(ru)
 
 
 def test_overlapping_jaccard():
@@ -167,12 +187,14 @@ def test_overlapping_and_nonoverlapping_hausdorff():
 
 
 if __name__ == "__main__":
-    test_netgen_mesh_creation()
-    test_spaces()
-    test_mark_none()
-    test_refine_udo()
-    test_refine_vces()
-    test_overlapping_jaccard()
-    test_nonoverlapping_jaccard()
-    test_symmetry_jaccard()
-    test_overlapping_and_nonoverlapping_hausdorff()
+    #test_netgen_mesh_creation()
+    #test_spaces()
+    #test_mark_none()
+    #test_refine_udo()
+    #test_refine_vces()
+    #test_overlapping_jaccard()
+    #test_nonoverlapping_jaccard()
+    #test_symmetry_jaccard()
+    #test_overlapping_and_nonoverlapping_hausdorff()
+    #test_petsc4py_refine_vces()
+    test_refine_vces_petsc4py_firedrake()


### PR DESCRIPTION
VIAMR.refinemarkedelements() is great!  Gutsy!

I added a test which avoids using netgen at all.  That seems desirable?

But see the FIXME.  How does the refined mesh get its coordinates?  They seem to get lost, but I am not sure that I am offsetting the coordinates on the original mesh the right way.