### PR TITLE
Refactor udo

### DIFF
--- a/NumericalResults/ConvergenceResults/Convergence.py
+++ b/NumericalResults/ConvergenceResults/Convergence.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
 
         elif method == methodlist[1]:  # udo
             mtic = time.perf_counter()
-            mark = amr_instance.udomarkParallel(mesh, u, lb, n=3)
+            mark = amr_instance.udomark(mesh, u, lb, n=3)
             mtoc = time.perf_counter()
             rtic = time.perf_counter()
             mesh = amr_instance.refinemarkedelements(mesh, mark)
@@ -144,7 +144,7 @@ if __name__ == "__main__":
                 rtoc = time.perf_counter()
 
             else:  # adapt
-                mark = amr_instance.udomarkParallel(mesh, u, lb, n=3)
+                mark = amr_instance.udomark(mesh, u, lb, n=3)
                 mtoc = time.perf_counter()
                 rtic = time.perf_counter()
                 mesh = amr_instance.refinemarkedelements(mesh, mark)
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 
         elif method == methodlist[7]:  # udo + br on inactive set
             mtic = time.perf_counter()
-            markFB = amr_instance.udomarkParallel(mesh, u, lb, n=3)
+            markFB = amr_instance.udomark(mesh, u, lb, n=3)
             resUFL = Constant(0.0) + div(grad(u))
             markBR = amr_instance.BRinactivemark(
                 mesh, u, lb, resUFL, .5, markFB)

--- a/NumericalResults/ConvergenceResults/ConvergenceLShaped.py
+++ b/NumericalResults/ConvergenceResults/ConvergenceLShaped.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
 
         elif method == methodlist[1]:  # udo
             mtic = time.perf_counter()
-            mark = amr_instance.udomarkParallel(mesh, u, lb, n=3)
+            mark = amr_instance.udomark(mesh, u, lb, n=3)
             mtoc = time.perf_counter()
             rtic = time.perf_counter()
             mesh = amr_instance.refinemarkedelements(mesh, mark)
@@ -148,7 +148,7 @@ if __name__ == "__main__":
                 rtoc = time.perf_counter()
 
             else:  # adapt
-                mark = amr_instance.udomarkParallel(mesh, u, lb, n=3)
+                mark = amr_instance.udomark(mesh, u, lb, n=3)
                 mtoc = time.perf_counter()
                 rtic = time.perf_counter()
                 mesh = amr_instance.refinemarkedelements(mesh, mark)
@@ -177,7 +177,7 @@ if __name__ == "__main__":
 
         elif method == methodlist[7]:  # udo + br on inactive set
             mtic = time.perf_counter()
-            markFB = amr_instance.udomarkParallel(mesh, u, lb, n=3)
+            markFB = amr_instance.udomark(mesh, u, lb, n=3)
             resUFL = Constant(0.0) + div(grad(u))
             markBR = amr_instance.BRinactivemark(
                 mesh, u, lb, resUFL, .5, markFB)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VI-AMR
+# VIAMR
 
 This repository contains algorithms for adaptive mesh refinement for variational inequalities (VIs).  The methods require the constraint set to be defined by a lower-bound inequality, that is, they are for unilateral obstacle problems.  A primary goal is to have targeted refinement near a computed free boundary, and to be able to measure location errors in the free boundary.  Refinement in the inactive set using PDE-type error estimators is also supported.
 
@@ -22,7 +22,7 @@ Now pip install [shapely](https://pypi.org/project/shapely/), siphash24, vtk, an
 pip install shapely siphash24 vtk ngspetsc
 ```
 
-## Installation of VI-AMR
+## Installation
 
 ### development install
 
@@ -74,10 +74,28 @@ The sphere problem has a known exact solution while the spiral problem does not.
 
 View the output fields in `result_*.pvd` using [Paraview](https://www.paraview.org/).  These files contain the obstacle `psi`, the solution `u`, and the gap `u - psi`. The `result_sphere.pvd` file also contains the numerical error `|u - uexact|`.
 
+## Limitations
+
+The most important limitation is that, at the current time, Netgen meshes, created with `SplineGeometry().GenerateMesh()`, have different refinement capabilities from Firedrake/DMPlex meshes, e.g. those created with the [Firedrake utility mesh generators](https://www.firedrakeproject.org/_modules/firedrake/utility_meshes.html).  Items 1 and 2 below are related to this fact.  Future bug fixes and feature improvements in PETSc DMPlex might change this.
+
+  1. [PETSc's DMPlex mesh transformations](https://petsc.org/release/overview/plex_transform_table/) include skeleton based refinement in 2D, but [currently not in 3D](https://petsc.org/release/src/dm/impls/plex/transform/impls/refine/sbr/plexrefsbr.c.html).  This limits the `VIAMR.refinemarkedelements()` to applications in 2D.
+  2. Parallel application of `VIAMR.udomark()` to Firedrake/DMPlex meshes requires that their distribution parameters be explicitly set.  For example, when using a utility mesh:
+  ```UnitSquareMesh(m0, m0, distribution_parameters={"partition": True, "overlap_type": (DistributedMeshOverlapType.VERTEX, 1)})```
+  3. For the reason given on [this issue](https://github.com/firedrakeproject/mpi-pytest/issues/13), use of [pytest](https://docs.pytest.org/en/stable/) cannot easily be extended to parallel using the [mpi-pytest](https://github.com/firedrakeproject/mpi-pytest) plugin.  Thus parallel regression testing is manual; see the bottom of this page.  Future bug fixes by the mpi-pytest developers could fix this.
+  4. `VIAMR.jaccard()` only works in parallel if one mesh is a submesh of the other.  See the doc string for that method.
+  5. `VIAMR.hausdorff()` does not work in parallel.  Also, it is the only part of VIAMR which depends on the [shapely](https://pypi.org/project/shapely/) library.
+
 ## Testing
 
-Software tests use [pytest](https://docs.pytest.org/en/stable/index.html). In the main directory `VI-AMR/` do
+Serial software tests use [pytest](https://docs.pytest.org/en/stable/index.html). In the main directory `VI-AMR/` do
 
 ```
 pytest .
 ```
+
+For parallel tests do the following or similar:
+```
+cd tests/
+mpiexec -n 3 python3 test_parallel.py
+```
+Success is completion without any error messages.

--- a/examples/pollutant.py
+++ b/examples/pollutant.py
@@ -92,8 +92,8 @@ for i in range(refinements + 1):
     if i == refinements:
         break
 
-    marklower = amr.udomarkParallel(u, lb, n=1)
-    markupper = amr.udomarkParallel(u, ub, n=1)
+    marklower = amr.udomark(u, lb, n=1)
+    markupper = amr.udomark(u, ub, n=1)
     _, DG0 = amr.spaces(mesh)
     mark = Function(DG0).interpolate((marklower + markupper) - (marklower * markupper))
     mesh = mesh.refine_marked_elements(mark)

--- a/examples/pollutant.py
+++ b/examples/pollutant.py
@@ -92,8 +92,8 @@ for i in range(refinements + 1):
     if i == refinements:
         break
 
-    marklower = amr.udomarkParallel(mesh, u, lb, n=1)
-    markupper = amr.udomarkParallel(mesh, u, ub, n=1)
+    marklower = amr.udomark(mesh, u, lb, n=1)
+    markupper = amr.udomark(mesh, u, ub, n=1)
     _, DG0 = amr.spaces(mesh)
     mark = Function(DG0).interpolate((marklower + markupper) - (marklower * markupper))
     mesh = mesh.refine_marked_elements(mark)

--- a/examples/spiral.py
+++ b/examples/spiral.py
@@ -27,7 +27,7 @@ for i in range(levels + 1):
     if i == levels:
         break
     mark = amr.udomark(u, lb, n=2)
-    # FIXME allow alternative?:  mark = amr.udomarkParallel(u, lb)
+    # FIXME allow alternative?:  mark = amr.udomark(u, lb)
     # alternative:  mark = amr.vcdmark(u, lb)
     mesh = mesh.refine_marked_elements(mark)
     meshHist.append(mesh)

--- a/examples/spiral.py
+++ b/examples/spiral.py
@@ -27,7 +27,7 @@ for i in range(levels + 1):
     if i == levels:
         break
     mark = amr.udomark(mesh, u, lb, n=2)
-    # FIXME allow alternative?:  mark = amr.udomarkParallel(mesh, u, lb)
+    # FIXME allow alternative?:  mark = amr.udomark(mesh, u, lb)
     # alternative:  mark = amr.vcdmark(mesh, u, lb)
     mesh = mesh.refine_marked_elements(mark)
     meshHist.append(mesh)

--- a/examples/suttmeier.py
+++ b/examples/suttmeier.py
@@ -73,6 +73,7 @@ for i in range(refinements + 1):
     # apply VCD AMR, marking inactive by B&R indicator
     #   (choose more refinement in active set, relative to default bracket=[0.2, 0.8])
     mark = amr.vcdmark(u, psi, bracket=[0.1, 0.8])
+    #mark = amr.udomark(u, psi, n = 2)
     residual = -div(grad(u)) - fsource
     (imark, _, _) = amr.brinactivemark(u, psi, residual)
     # imark = amr.eleminactive(u, psi)  # alternative is to refine all inactive

--- a/examples/suttmeier.py
+++ b/examples/suttmeier.py
@@ -12,7 +12,7 @@ from viamr import VIAMR
 
 print = PETSc.Sys.Print  # enables correct printing in parallel
 
-refinements = 6
+refinements = 4
 m0 = 10
 outfile = "result_suttmeier.pvd"
 
@@ -32,8 +32,10 @@ params = {
     "pc_factor_mat_solver_type": "mumps",
 }
 
+# explicitly setting distribution parameters allows this to be a udomark() example
+# which still runs in parallel
 meshhierarchy = [
-    UnitSquareMesh(m0, m0),
+    UnitSquareMesh(m0, m0, diagonal="crossed", distribution_parameters={"partition": True, "overlap_type": (DistributedMeshOverlapType.VERTEX, 1)}),
 ]
 amr = VIAMR()
 for i in range(refinements + 1):
@@ -70,10 +72,12 @@ for i in range(refinements + 1):
     if i == refinements:
         break
 
-    # apply VCD AMR, marking inactive by B&R indicator
+    mark = amr.udomark(u, psi, n = 2)
+
+    # alternative: apply VCD AMR, marking inactive by B&R indicator
     #   (choose more refinement in active set, relative to default bracket=[0.2, 0.8])
-    mark = amr.vcdmark(u, psi, bracket=[0.1, 0.8])
-    #mark = amr.udomark(u, psi, n = 2)
+    # mark = amr.vcdmark(u, psi, bracket=[0.1, 0.8])
+
     residual = -div(grad(u)) - fsource
     (imark, _, _) = amr.brinactivemark(u, psi, residual)
     # imark = amr.eleminactive(u, psi)  # alternative is to refine all inactive

--- a/tests/3drefine.py
+++ b/tests/3drefine.py
@@ -8,9 +8,8 @@ amr = VIAMR()
 mesh = BoxMesh(5, 5, 10, 1, 1, 1)
 DG0 = FunctionSpace(mesh, "DG", 0)
 (x, y, z) = SpatialCoordinate(mesh)
-indicator = Function(DG0).interpolate(conditional(x>.5, 1, 0))
+indicator = Function(DG0).interpolate(conditional(x > 0.5, 1, 0))
 
 refinedmesh = amr.refinemarkedelements(mesh, indicator)
 
 VTKFile("3d.pvd").write(refinedmesh)
-

--- a/tests/compareSolution.py
+++ b/tests/compareSolution.py
@@ -7,17 +7,29 @@ import subprocess
 z = VIAMR()
 
 
-subprocess.run(["python3", "generateSolution.py", "--refinements", "2", "--runtime", "serial"])
 subprocess.run(
-    ["mpiexec", "-n", "4", "python3", "generateSolution.py",
-     "--refinements", "2", "--runtime", "parallel"])
+    ["python3", "generateSolution.py", "--refinements", "2", "--runtime", "serial"]
+)
+subprocess.run(
+    [
+        "mpiexec",
+        "-n",
+        "4",
+        "python3",
+        "generateSolution.py",
+        "--refinements",
+        "2",
+        "--runtime",
+        "parallel",
+    ]
+)
 
-with CheckpointFile("serialUDO.h5", 'r') as afile:
-    serialMesh = afile.load_mesh("serialMesh") 
+with CheckpointFile("serialUDO.h5", "r") as afile:
+    serialMesh = afile.load_mesh("serialMesh")
     serialMark = afile.load_function(serialMesh, "serialMark")
-    
-    
-with CheckpointFile("parallelUDO.h5", 'r') as afile:
+
+
+with CheckpointFile("parallelUDO.h5", "r") as afile:
     parallelMesh = afile.load_mesh("parallelMesh")
     parallelMark = afile.load_function(parallelMesh, "parallelMark")
 

--- a/tests/generateSolution.py
+++ b/tests/generateSolution.py
@@ -12,13 +12,20 @@ from firedrake.petsc import PETSc
 # mpiexec -n 4 python3 generateSolution.py --refinements 2 --runtime parallel
 
 # Parse command-line arguments
-parser = argparse.ArgumentParser(
-    description='Script for Parallel UDO Ideas Testing')
-parser.add_argument('--refinements', type=int, default=3,
-                    help='Number of refinement levels (default: 1)')
-parser.add_argument('--runtime', type=str, default='serial',
-                    choices=['serial', 'parallel'],
-                    help='Runtime type (options: serial, parallel)')
+parser = argparse.ArgumentParser(description="Script for Parallel UDO Ideas Testing")
+parser.add_argument(
+    "--refinements",
+    type=int,
+    default=3,
+    help="Number of refinement levels (default: 1)",
+)
+parser.add_argument(
+    "--runtime",
+    type=str,
+    default="serial",
+    choices=["serial", "parallel"],
+    help="Runtime type (options: serial, parallel)",
+)
 args = parser.parse_args()
 
 # Generate Mesh
@@ -39,7 +46,7 @@ for i in range(args.refinements):
     PETSc.Sys.Print("UDO marking")
     mark = z.udomark(mesh, u, lb, n=1)
     PETSc.Sys.Print("UDO marked")
-    
+
     if i < args.refinements - 1:
         PETSc.Sys.Print("refining")
         mesh = z.refinemarkedelements(mesh, mark)
@@ -49,8 +56,8 @@ if args.refinements > 0:
     mesh.name = f"{args.runtime}Mesh"
     mark.rename(f"{args.runtime}Mark")
 
-#VTKFile(f"results{args.runtime}.pvd").write(mark)
+# VTKFile(f"results{args.runtime}.pvd").write(mark)
 
-with CheckpointFile(f"{args.runtime}UDO.h5", 'w') as afile:
+with CheckpointFile(f"{args.runtime}UDO.h5", "w") as afile:
     afile.save_mesh(mesh)
     afile.save_function(mark)

--- a/tests/generateSolution.py
+++ b/tests/generateSolution.py
@@ -37,7 +37,7 @@ for i in range(args.refinements):
     PETSc.Sys.Print("problem solved")
 
     PETSc.Sys.Print("UDO marking")
-    mark = z.udomarkParallel(mesh, u, lb, n=1)
+    mark = z.udomark(mesh, u, lb, n=1)
     PETSc.Sys.Print("UDO marked")
     
     if i < args.refinements - 1:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,63 +5,9 @@ from viamr import VIAMR
 import subprocess
 import os
 import pathlib
-from pytest_mpi import parallel_assert
 
 
-class VIAMRRegression(VIAMR):
-    def __init__(self):
-        super().__init__()
-        
-    def _bfsneighbors(self, mesh, border, levels):
-        """Element-wise multi-neighbor lookup using breadth-first search."""
-        from collections import deque
-        # build dictionary which maps each vertex in the mesh
-        # to the cells that are incident to it
-        vertex_to_cells = {}
-        closure = mesh.topology.cell_closure  # cell to vertex connectivity
-        # loop over all cells to populate the dictionary
-        for i in range(mesh.num_cells()):
-            # first three entries correspond to the vertices
-            for vertex in closure[i][:3]:
-                if vertex not in vertex_to_cells:
-                    vertex_to_cells[vertex] = []
-                vertex_to_cells[vertex].append(i)
-
-        # loop over all cells to mark neighbors, and store the result in DG0
-        result = Function(border.function_space(), name="nNeighbors")
-        for i in range(mesh.num_cells()):
-            if border.dat.data[i] == 1.0:
-                # use BFS to find all cells within the specified number of levels
-                queue = deque([(i, 0)])
-                visited = set()
-                while queue:
-                    cell, level = queue.popleft()
-                    if cell not in visited and level <= levels:
-                        visited.add(cell)
-                        result.dat.data[cell] = 1
-                        for vertex in closure[cell][:3]:
-                            for neighbor in vertex_to_cells[vertex]:
-                                queue.append((neighbor, level + 1))
-        return result
-    
-    def udomarkOLD(self, uh, lb, n=2):
-        """Mark mesh using Unstructured Dilation Operator (UDO) algorithm."""
-        mesh = uh.function_space().mesh()
-        if mesh.comm.size > 1:
-            raise ValueError("udomark() is not valid in parallel")
-        # generate element-wise indicator for border set
-        elemborder = self.elemborder(self.nodalactive(uh, lb))
-        # _bfs_neighbors() constructs N^n(B) indicator
-        return self._bfsneighbors(mesh, elemborder, n)
-
-
-
-# for parallel testing
-from mpi4py import MPI
-from pytest_mpi.parallel_assert import parallel_assert
-
-
-def get_netgen_mesh(TriHeight=0.4, width=2):
+def _get_netgen_mesh(TriHeight=0.4, width=2):
     import netgen
     from netgen.geom2d import SplineGeometry
 
@@ -80,19 +26,7 @@ def get_netgen_mesh(TriHeight=0.4, width=2):
     )
 
 
-def test_netgen_mesh_creation():
-    mesh = get_netgen_mesh()
-    assert mesh.num_cells() == 228
-
-
-def test_spaces():
-    mesh = get_netgen_mesh(TriHeight=1.2)
-    CG1, DG0 = VIAMR(debug=True).spaces(mesh)
-    assert CG1.dim() == 19
-    assert DG0.dim() == 24
-
-
-def get_ball_obstacle(x, y):
+def _get_ball_obstacle(x, y):
     r = sqrt(x * x + y * y)
     r0 = 0.9
     psi0 = np.sqrt(1.0 - r0 * r0)
@@ -100,12 +34,24 @@ def get_ball_obstacle(x, y):
     return conditional(le(r, r0), sqrt(1.0 - r * r), psi0 + dpsi0 * (r - r0))
 
 
+def test_netgen_mesh_creation():
+    mesh = _get_netgen_mesh()
+    assert mesh.num_cells() == 228
+
+
+def test_spaces():
+    mesh = _get_netgen_mesh(TriHeight=1.2)
+    CG1, DG0 = VIAMR(debug=True).spaces(mesh)
+    assert CG1.dim() == 19
+    assert DG0.dim() == 24
+
+
 def test_mark_none():
-    mesh = get_netgen_mesh(TriHeight=1.2)
+    mesh = _get_netgen_mesh(TriHeight=1.2)
     amr = VIAMR(debug=True)
     CG1, _ = amr.spaces(mesh)
     (x, y) = SpatialCoordinate(mesh)
-    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
+    psi = Function(CG1).interpolate(_get_ball_obstacle(x, y))
     mark = amr.udomark(psi, psi)  # all active
     assert norm(mark, "L1") == 0.0
     mark = amr.vcdmark(psi, psi)  # all active
@@ -125,19 +71,19 @@ def test_unionmarks():
     _, DG0 = amr.spaces(mesh)
     (x, y) = SpatialCoordinate(mesh)
     rightmark = Function(DG0).interpolate(conditional(x > 0.0, 1.0, 0.0))
-    discmark = Function(DG0).interpolate(get_ball_obstacle(x, y) > 0.0)
+    discmark = Function(DG0).interpolate(_get_ball_obstacle(x, y) > 0.0)
     mark = amr.unionmarks(rightmark, discmark)
     # VTKFile(f"result_unionmarks.pvd").write(rightmark, discmark, mark)
     assert abs(assemble(mark * dx) - 9.92) < 1.0e-10  # union of marked area
 
 
 def test_refine_udo():
-    mesh = get_netgen_mesh(TriHeight=1.2)
+    mesh = _get_netgen_mesh(TriHeight=1.2)
     amr = VIAMR(debug=True)
     CG1, _ = amr.spaces(mesh)
     assert CG1.dim() == 19
     (x, y) = SpatialCoordinate(mesh)
-    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
+    psi = Function(CG1).interpolate(_get_ball_obstacle(x, y))
     u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
     unorm0 = norm(u)
     # VTKFile(f"result_refine_0.pvd").write(u)
@@ -151,39 +97,13 @@ def test_refine_udo():
     # VTKFile(f"result_refine_1.pvd").write(ru)
 
 
-def test_refine_udo_parallelUDO():
-    mesh1 = get_netgen_mesh(TriHeight=0.1)
-    amr = VIAMR(debug=True)
-    CG1, _ = amr.spaces(mesh1)
-    (x, y) = SpatialCoordinate(mesh1)
-    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
-    u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
-    unorm0 = norm(u)
-    # VTKFile(f"result_refine_0.pvd").write(u)
-    mark1 = amr.udomark(u, psi)
-    rmesh1 = mesh1.refine_marked_elements(mark1)  # netgen's refine method
-    mesh2 = get_netgen_mesh(TriHeight=0.1)
-    CG1, _ = amr.spaces(mesh2)
-    (x, y) = SpatialCoordinate(mesh1)
-    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
-    u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
-    unorm0 = norm(u)
-    # VTKFile("result_refine_0.pvd").write(u)
-    mark2 = amr.udomark(u, psi)
-    rmesh2 = mesh2.refine_marked_elements(mark2)  # netgen's refine method
-    assert abs(amr.jaccard(mark1, mark2) - 1.0) < 1.0e-10
-    r1CG1, _ = amr.spaces(rmesh1)
-    r2CG1, _ = amr.spaces(rmesh2)
-    assert r1CG1.dim() == r2CG1.dim()
-
-
 def test_refine_vcd():
-    mesh = get_netgen_mesh(TriHeight=1.2)
+    mesh = _get_netgen_mesh(TriHeight=1.2)
     amr = VIAMR(debug=True)
     CG1, _ = amr.spaces(mesh)
     assert CG1.dim() == 19
     (x, y) = SpatialCoordinate(mesh)
-    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
+    psi = Function(CG1).interpolate(_get_ball_obstacle(x, y))
     u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
     unorm0 = norm(u)
     mark = amr.vcdmark(u, psi)
@@ -196,12 +116,12 @@ def test_refine_vcd():
 
 
 def test_petsc4py_refine_vcd():
-    mesh = get_netgen_mesh(TriHeight=1.2)
+    mesh = _get_netgen_mesh(TriHeight=1.2)
     amr = VIAMR(debug=True)
     CG1, _ = amr.spaces(mesh)
     assert CG1.dim() == 19
     (x, y) = SpatialCoordinate(mesh)
-    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
+    psi = Function(CG1).interpolate(_get_ball_obstacle(x, y))
     u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
     unorm0 = norm(u)
     mark = amr.vcdmark(u, psi)
@@ -221,7 +141,7 @@ def test_refine_vcd_petsc4py_firedrake():
     CG1, _ = amr.spaces(mesh)
     assert CG1.dim() == 36
     (x, y) = SpatialCoordinate(mesh)
-    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
+    psi = Function(CG1).interpolate(_get_ball_obstacle(x, y))
     u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
     unorm0 = norm(u)
     mark = amr.vcdmark(u, psi)
@@ -239,7 +159,7 @@ def test_gradrecinactivemark():
     CG1, _ = amr.spaces(mesh)
     assert CG1.dim() == 85
     (x, y) = SpatialCoordinate(mesh)
-    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
+    psi = Function(CG1).interpolate(_get_ball_obstacle(x, y))
     u = Function(CG1).interpolate(conditional(psi > 0.0, psi + 1.0, psi))
     imark, _ = amr.gradrecinactivemark(u, psi, theta=0.5)
     # VTKFile(f"result_gradrecinactivemark.pvd").write(Function(CG1, name="diff").interpolate(u-psi), imark)
@@ -255,7 +175,7 @@ def test_brinactivemark():
     CG1, _ = amr.spaces(mesh)
     assert CG1.dim() == 81
     (x, y) = SpatialCoordinate(mesh)
-    psi = Function(CG1).interpolate(get_ball_obstacle(x, y))
+    psi = Function(CG1).interpolate(_get_ball_obstacle(x, y))
     u = Function(CG1).interpolate(conditional(psi > 0.0, psi + 1.0, psi))
     residual = -div(grad(u))  # largest near circle psi==0
     (imark, _, _) = amr.brinactivemark(u, psi, residual, theta=0.8)
@@ -267,7 +187,7 @@ def test_brinactivemark():
 
 
 def test_overlapping_jaccard():
-    mesh = get_netgen_mesh(TriHeight=1.2)
+    mesh = _get_netgen_mesh(TriHeight=1.2)
     amr = VIAMR(debug=True)
     _, DG0 = amr.spaces(mesh)
     x, _ = SpatialCoordinate(mesh)
@@ -278,7 +198,7 @@ def test_overlapping_jaccard():
 
 
 def test_nonoverlapping_jaccard():
-    mesh = get_netgen_mesh()
+    mesh = _get_netgen_mesh()
     amr = VIAMR(debug=True)
     _, DG0 = amr.spaces(mesh)
     x, _ = SpatialCoordinate(mesh)
@@ -290,7 +210,7 @@ def test_nonoverlapping_jaccard():
 
 
 def test_symmetry_jaccard():
-    mesh = get_netgen_mesh()
+    mesh = _get_netgen_mesh()
     amr = VIAMR(debug=True)
     _, DG0 = amr.spaces(mesh)
     x, _ = SpatialCoordinate(mesh)
@@ -314,63 +234,6 @@ def test_overlapping_and_nonoverlapping_hausdorff():
     lb2 = Function(CG1).interpolate(conditional(x <= 0.4, 1, 0))
     _, E2 = amr.freeboundarygraph(sol1, lb2)
     assert amr.hausdorff(E1, E2) == 0.2
-    
-    
-@pytest.mark.parallel(nprocs=3)
-def test_parallel_udo():
-    comm = MPI.COMM_WORLD
-    rank = comm.Get_rank()
-    
-    
-    amr = VIAMR()
-    mesh =  RectangleMesh(20, 20, 1, 1, distribution_parameters={"partition": True, "overlap_type": (DistributedMeshOverlapType.VERTEX, 1)})
-    CG1, _ = amr.spaces(mesh)
-    u = Function(CG1).interpolate(1.0)
-    x, y = SpatialCoordinate(mesh)
-    
-    # Somewhat interesting obstacle configuration. 
-    lb = Function(CG1).interpolate(
-       conditional(And(And(x > 0.15, x < 0.35), And(y > 0.15, y < 0.35)), 1.0,
-        conditional(And(And(x > 0.65, x < 0.85), And(y > 0.15, y < 0.35)), 1.0,
-        conditional(And(And(x > 0.15, x < 0.35), And(y > 0.65, y < 0.85)), 1.0,
-        conditional(And(And(x > 0.65, x < 0.85), And(y > 0.65, y < 0.85)), 1.0, 0.0))))
-    )
-    
-    # Mark in parallel
-    mark = amr.udomark(u, lb, n = 2)
-    
-    # Compute number of local active elements
-    localActive = np.sum(mark.dat.data_ro[:])
-    globalActive = np.zeros(1, dtype=np.float64)
-    comm.Allreduce(localActive, globalActive, op=MPI.SUM)
-    
-    if rank == 0:
-        # Check agreement with serial implementation
-        assert globalActive[0] == 506
-    
-
-def test_udo_regression():
-    # This test utilizes the the old implementation of UDO which builds the neighborhood of the free boundary using breadth first search, 
-    # as a regression test for the dmplex based implementation. 
-    
-    amr = VIAMRRegression()
-    mesh =  RectangleMesh(20, 20, 1, 1, distribution_parameters={"partition": True, "overlap_type": (DistributedMeshOverlapType.VERTEX, 1)})
-    CG1, _ = amr.spaces(mesh)
-    u = Function(CG1).interpolate(1.0)
-    x, y = SpatialCoordinate(mesh)
-    
-    # Somewhat interesting obstacle configuration. 
-    lb = Function(CG1).interpolate(
-       conditional(And(And(x > 0.15, x < 0.35), And(y > 0.15, y < 0.35)), 1.0,
-        conditional(And(And(x > 0.65, x < 0.85), And(y > 0.15, y < 0.35)), 1.0,
-        conditional(And(And(x > 0.15, x < 0.35), And(y > 0.65, y < 0.85)), 1.0,
-        conditional(And(And(x > 0.65, x < 0.85), And(y > 0.65, y < 0.85)), 1.0, 0.0))))
-    )
-
-    markold = amr.udomarkOLD(u, lb, n = 2)
-    marknew = amr.udomark(u, lb, n = 2)
-    assert amr.jaccard(markold, marknew) == 1.0
-    
 
 
 if __name__ == "__main__":
@@ -385,8 +248,5 @@ if __name__ == "__main__":
     test_nonoverlapping_jaccard()
     test_symmetry_jaccard()
     test_overlapping_and_nonoverlapping_hausdorff()
-    test_refine_udo_parallelUDO()
     test_petsc4py_refine_vcd()
     test_refine_vcd_petsc4py_firedrake()
-    test_udo_regression()
-    test_parallel_udo()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -115,7 +115,7 @@ def test_refine_udo_parallelUDO():
     u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
     unorm0 = norm(u)
     # VTKFile("result_refine_0.pvd").write(u)
-    mark2 = amr.udomarkParallel(mesh1, u, psi)
+    mark2 = amr.udomark(mesh1, u, psi)
     rmesh2 = mesh2.refine_marked_elements(mark2)  # netgen's refine method
     assert amr.jaccard(mark1, mark2) == 1.0
     r1CG1, _ = amr.spaces(rmesh1)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -14,7 +14,7 @@ class VIAMRRegression(VIAMR):
         
     def _bfsneighbors(self, mesh, border, levels):
         """Element-wise multi-neighbor lookup using breadth-first search."""
-
+        from collections import deque
         # build dictionary which maps each vertex in the mesh
         # to the cells that are incident to it
         vertex_to_cells = {}
@@ -316,7 +316,7 @@ def test_overlapping_and_nonoverlapping_hausdorff():
     assert amr.hausdorff(E1, E2) == 0.2
     
     
-@pytest.mark.parallel(nprocs=4)
+@pytest.mark.parallel(nprocs=3)
 def test_parallel_udo():
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
@@ -337,7 +337,7 @@ def test_parallel_udo():
     )
     
     # Mark in parallel
-    mark = amr.udomark(mesh, u, lb, n = 2)
+    mark = amr.udomark(u, lb, n = 2)
     
     # Compute number of local active elements
     localActive = np.sum(mark.dat.data_ro[:])
@@ -367,8 +367,8 @@ def test_udo_regression():
         conditional(And(And(x > 0.65, x < 0.85), And(y > 0.65, y < 0.85)), 1.0, 0.0))))
     )
 
-    markold = amr.udomarkOLD(mesh, u, lb, n = 2)
-    marknew = amr.udomark(mesh, u, lb, n = 2)
+    markold = amr.udomarkOLD(u, lb, n = 2)
+    marknew = amr.udomark(u, lb, n = 2)
     assert amr.jaccard(markold, marknew) == 1.0
     
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,188 @@
+import numpy as np
+import pytest
+from firedrake import *
+from viamr import VIAMR
+import subprocess
+import os
+import pathlib
+
+from test_basic import _get_netgen_mesh, _get_ball_obstacle
+
+from mpi4py import MPI
+from pytest_mpi.parallel_assert import parallel_assert
+from pytest_mpi import parallel_assert
+
+
+class VIAMRRegression(VIAMR):
+    def __init__(self):
+        super().__init__()
+
+    def _bfsneighbors(self, mesh, border, levels):
+        """Element-wise multi-neighbor lookup using breadth-first search."""
+        from collections import deque
+
+        # build dictionary which maps each vertex in the mesh
+        # to the cells that are incident to it
+        vertex_to_cells = {}
+        closure = mesh.topology.cell_closure  # cell to vertex connectivity
+        # loop over all cells to populate the dictionary
+        for i in range(mesh.num_cells()):
+            # first three entries correspond to the vertices
+            for vertex in closure[i][:3]:
+                if vertex not in vertex_to_cells:
+                    vertex_to_cells[vertex] = []
+                vertex_to_cells[vertex].append(i)
+
+        # loop over all cells to mark neighbors, and store the result in DG0
+        result = Function(border.function_space(), name="nNeighbors")
+        for i in range(mesh.num_cells()):
+            if border.dat.data[i] == 1.0:
+                # use BFS to find all cells within the specified number of levels
+                queue = deque([(i, 0)])
+                visited = set()
+                while queue:
+                    cell, level = queue.popleft()
+                    if cell not in visited and level <= levels:
+                        visited.add(cell)
+                        result.dat.data[cell] = 1
+                        for vertex in closure[cell][:3]:
+                            for neighbor in vertex_to_cells[vertex]:
+                                queue.append((neighbor, level + 1))
+        return result
+
+    def udomarkOLD(self, uh, lb, n=2):
+        """Mark mesh using Unstructured Dilation Operator (UDO) algorithm."""
+        mesh = uh.function_space().mesh()
+        if mesh.comm.size > 1:
+            raise ValueError("udomark() is not valid in parallel")
+        # generate element-wise indicator for border set
+        elemborder = self.elemborder(self.nodalactive(uh, lb))
+        # _bfs_neighbors() constructs N^n(B) indicator
+        return self._bfsneighbors(mesh, elemborder, n)
+
+
+def PARtest_refine_udo_parallelUDO():
+    mesh1 = _get_netgen_mesh(TriHeight=0.1)
+    amr = VIAMR(debug=True)
+    CG1, _ = amr.spaces(mesh1)
+    (x, y) = SpatialCoordinate(mesh1)
+    psi = Function(CG1).interpolate(_get_ball_obstacle(x, y))
+    u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
+    unorm0 = norm(u)
+    # VTKFile(f"result_refine_0.pvd").write(u)
+    mark1 = amr.udomark(u, psi)
+    rmesh1 = mesh1.refine_marked_elements(mark1)  # netgen's refine method
+    mesh2 = _get_netgen_mesh(TriHeight=0.1)
+    CG1, _ = amr.spaces(mesh2)
+    (x, y) = SpatialCoordinate(mesh1)
+    psi = Function(CG1).interpolate(_get_ball_obstacle(x, y))
+    u = Function(CG1).interpolate(conditional(psi > 0.0, psi, 0.0))
+    unorm0 = norm(u)
+    # VTKFile("result_refine_0.pvd").write(u)
+    mark2 = amr.udomark(u, psi)
+    rmesh2 = mesh2.refine_marked_elements(mark2)  # netgen's refine method
+    assert abs(amr.jaccard(mark1, mark2) - 1.0) < 1.0e-10
+    r1CG1, _ = amr.spaces(rmesh1)
+    r2CG1, _ = amr.spaces(rmesh2)
+    assert r1CG1.dim() == r2CG1.dim()
+
+
+@pytest.mark.parallel(nprocs=3)
+def PARtest_parallel_udo():
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    amr = VIAMR()
+    mesh = RectangleMesh(
+        20,
+        20,
+        1,
+        1,
+        distribution_parameters={
+            "partition": True,
+            "overlap_type": (DistributedMeshOverlapType.VERTEX, 1),
+        },
+    )
+    CG1, _ = amr.spaces(mesh)
+    u = Function(CG1).interpolate(1.0)
+    x, y = SpatialCoordinate(mesh)
+
+    # Somewhat interesting obstacle configuration.
+    lb = Function(CG1).interpolate(
+        conditional(
+            And(And(x > 0.15, x < 0.35), And(y > 0.15, y < 0.35)),
+            1.0,
+            conditional(
+                And(And(x > 0.65, x < 0.85), And(y > 0.15, y < 0.35)),
+                1.0,
+                conditional(
+                    And(And(x > 0.15, x < 0.35), And(y > 0.65, y < 0.85)),
+                    1.0,
+                    conditional(
+                        And(And(x > 0.65, x < 0.85), And(y > 0.65, y < 0.85)), 1.0, 0.0
+                    ),
+                ),
+            ),
+        )
+    )
+
+    # Mark in parallel
+    mark = amr.udomark(u, lb, n=2)
+
+    # Compute number of local active elements
+    localActive = np.sum(mark.dat.data_ro[:])
+    globalActive = np.zeros(1, dtype=np.float64)
+    comm.Allreduce(localActive, globalActive, op=MPI.SUM)
+
+    if rank == 0:
+        # Check agreement with serial implementation
+        assert globalActive[0] == 506
+
+
+def PARtest_udo_regression():
+    # This test utilizes the the old implementation of UDO which builds the neighborhood of the free boundary using breadth first search,
+    # as a regression test for the dmplex based implementation.
+
+    amr = VIAMRRegression()
+    mesh = RectangleMesh(
+        20,
+        20,
+        1,
+        1,
+        distribution_parameters={
+            "partition": True,
+            "overlap_type": (DistributedMeshOverlapType.VERTEX, 1),
+        },
+    )
+    CG1, _ = amr.spaces(mesh)
+    u = Function(CG1).interpolate(1.0)
+    x, y = SpatialCoordinate(mesh)
+
+    # Somewhat interesting obstacle configuration.
+    lb = Function(CG1).interpolate(
+        conditional(
+            And(And(x > 0.15, x < 0.35), And(y > 0.15, y < 0.35)),
+            1.0,
+            conditional(
+                And(And(x > 0.65, x < 0.85), And(y > 0.15, y < 0.35)),
+                1.0,
+                conditional(
+                    And(And(x > 0.15, x < 0.35), And(y > 0.65, y < 0.85)),
+                    1.0,
+                    conditional(
+                        And(And(x > 0.65, x < 0.85), And(y > 0.65, y < 0.85)), 1.0, 0.0
+                    ),
+                ),
+            ),
+        )
+    )
+
+    markold = amr.udomarkOLD(u, lb, n=2)
+    marknew = amr.udomark(u, lb, n=2)
+    assert amr.jaccard(markold, marknew) == 1.0
+
+
+if __name__ == "__main__":
+    PARtest_refine_udo_parallelUDO()
+    PARtest_udo_regression()
+    PARtest_parallel_udo()

--- a/viamr/viamr.py
+++ b/viamr/viamr.py
@@ -138,7 +138,7 @@ class VIAMR(OptionsManager):
                                 queue.append((neighbor, level + 1))
         return result
 
-    def udomark(self, mesh, u, lb, n=2):
+    def udomarkOLD(self, mesh, u, lb, n=2):
         """Mark mesh using Unstructured Dilation Operator (UDO) algorithm."""
         if mesh.comm.size > 1:
             raise ValueError("udomark() is not valid in parallel")
@@ -147,7 +147,7 @@ class VIAMR(OptionsManager):
         # _bfs_neighbors() constructs N^n(B) indicator
         return self._bfsneighbors(mesh, elemborder, n)
 
-    def udomarkParallel(self, mesh, u, lb, n=2):
+    def udomark(self, mesh, u, lb, n=2):
         """Mark mesh using Unstructured Dilation Operator (UDO) algorithm. Update to latest ngsPETSc otherwise refinement must be done with PETSc refinemarkedelements"""
 
         # Generate element-wise and nodal-wise indicators for active set

--- a/viamr/viamr.py
+++ b/viamr/viamr.py
@@ -1,6 +1,5 @@
 import sys
 import numpy as np
-from collections import deque
 from firedrake import *
 from firedrake.petsc import OptionsManager, PETSc
 from firedrake.output import VTKFile

--- a/viamr/viamr.py
+++ b/viamr/viamr.py
@@ -138,15 +138,13 @@ class VIAMR(OptionsManager):
         #
 
         DistParams = mesh._distribution_parameters
-
-        if (
-            DistParams["overlap_type"][0].name != "VERTEX"
-            or DistParams["overlap_type"][1] < 1
-        ):
-            # We will error out instead
-            raise ValueError(
-                """Error: For UDO to work ensure that distribution_parameters={"partition": True, "overlap_type": (DistributedMeshOverlapType.VERTEX, 1)} on mesh initialization."""
-            )
+        
+        if MPI.COMM_WORLD.Get_size() > 1:
+            if (DistParams["overlap_type"][0].name != "VERTEX" or DistParams["overlap_type"][1] < 1):
+                # We will error out instead
+                raise ValueError(
+                    """Error: For UDO to work ensure that distribution_parameters={"partition": True, "overlap_type": (DistributedMeshOverlapType.VERTEX, 1)} on mesh initialization."""
+                )
 
             # This workaround works for firedrake meshes, not netgen. It also forces me to return the mesh which is a bad user pattern.
             # MPI.COMM_WORLD.Barrier()

--- a/viamr/viamr.py
+++ b/viamr/viamr.py
@@ -115,16 +115,6 @@ class VIAMR(OptionsManager):
 
 
     def udomark(self, uh, lb, n=2):
-        """Mark mesh using Unstructured Dilation Operator (UDO) algorithm."""
-        mesh = uh.function_space().mesh()
-        if mesh.comm.size > 1:
-            raise ValueError("udomark() is not valid in parallel")
-        # generate element-wise indicator for border set
-        elemborder = self.elemborder(self.nodalactive(uh, lb))
-        # _bfs_neighbors() constructs N^n(B) indicator
-        return self._bfsneighbors(mesh, elemborder, n)
-
-    def udomarkParallel(self, uh, lb, n=2):
         """Mark mesh using Unstructured Dilation Operator (UDO) algorithm. Update to latest ngsPETSc otherwise refinement must be done with PETSc refinemarkedelements"""
 
         # Generate element-wise and nodal-wise indicators for active set


### PR DESCRIPTION
So I made parallelUDO the main marking UDO marking method. I moved the old implementation into a subclass inside of the test_basic for regression testing. There is now both a regression test called test_udo_regression(): and a parallel test  test_parallel_udo(): The parallel test is behaving weirdly on a fresh firedrake install. It will fail with a subprocess error when running in forking mode i.e. running just` pytest`. But when running in nonforking mode i.e. using ` mpiexec -n 3 pytest -m parallel[3]` it passes. My december build of firedrake has passes with both modes. 